### PR TITLE
Add patch for a segfault while outputting xml.

### DIFF
--- a/recipe/doxygen-1.8.13-NULL-dereference.patch
+++ b/recipe/doxygen-1.8.13-NULL-dereference.patch
@@ -1,0 +1,24 @@
+From 0f02761a158a5e9ddbd5801682482af8986dbc35 Mon Sep 17 00:00:00 2001
+From: albert-github <albert.tests@gmail.com>
+Date: Wed, 4 Jan 2017 12:24:55 +0100
+Subject: [PATCH] Bug 776791 - [1.8.13 Regression] Segfault building the
+ breathe docs
+
+Protected against NULL pointer of variable al
+---
+ src/xmlgen.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/xmlgen.cpp b/src/xmlgen.cpp
+index fe95c7a..70e198a 100644
+--- a/src/xmlgen.cpp
++++ b/src/xmlgen.cpp
+@@ -620,7 +620,7 @@ static void generateXMLForMember(MemberDef *md,FTextStream &ti,FTextStream &t,De
+     if (md->isInline()) t << "yes"; else t << "no";
+     t << "\"";
+ 
+-    if (al->refQualifier!=RefQualifierNone)
++    if (al!=0 && al->refQualifier!=RefQualifierNone)
+     {
+       t << " refqual=\"";
+       if (al->refQualifier==RefQualifierLValue) t << "lvalue"; else t << "rvalue";

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,7 +28,7 @@ source:
     - doxygen-1.8.13-NULL-dereference.patch
   
 build:
-  number: 0
+  number: 1
   skip: True  # [not py35 and unix]
   script:                                                  # [win]
       - mkdir %SCRIPTS%                                    # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,7 +25,7 @@ source:
     - find_iconv.patch                                                           # [not win]
     # Doxygen 1.8.13 sometimes segfaults when building the XML output:
     # https://github.com/doxygen/doxygen/pull/555
-    - doxygen-1.8.13-NULL-dereference.patch
+    - doxygen-1.8.13-NULL-dereference.patch                                      # [not win]
   
 build:
   number: 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,6 +23,9 @@ source:
     # CMake finds iconv_open in glibc, but finds iconv.h from libiconv.
     # Make sure both are found from one place.
     - find_iconv.patch                                                           # [not win]
+    # Doxygen 1.8.13 sometimes segfaults when building the XML output:
+    # https://github.com/doxygen/doxygen/pull/555
+    - doxygen-1.8.13-NULL-dereference.patch
   
 build:
   number: 0


### PR DESCRIPTION
See https://github.com/doxygen/doxygen/pull/555

We ran into this issue while building the docs for pagmo2 on travis, using the doxygen package from conda.