### PR TITLE
Update to really build in Windows

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -24,3 +24,5 @@ target_platform:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
+- - cdt_name
+  - docker_image

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -5,7 +5,7 @@ c_compiler:
 c_compiler_version:
 - '11'
 channel_sources:
-- conda-forge
+- conda-forge/label/rust_dev,conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -1,6 +1,15 @@
+c_compiler:
+- vs2017
 channel_sources:
 - conda-forge,defaults
 channel_targets:
 - conda-forge main
+cxx_compiler:
+- vs2017
+libiconv:
+- '1.16'
+pin_run_as_build:
+  libiconv:
+    max_pin: x.x
 target_platform:
 - win-64

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -6,8 +6,14 @@
 # benefit from the improvement.
 
 set -xeuo pipefail
-export PYTHONUNBUFFERED=1
 export FEEDSTOCK_ROOT="${FEEDSTOCK_ROOT:-/home/conda/feedstock_root}"
+source ${FEEDSTOCK_ROOT}/.scripts/logging_utils.sh
+
+
+endgroup "Start Docker"
+
+startgroup "Configuring conda"
+export PYTHONUNBUFFERED=1
 export RECIPE_ROOT="${RECIPE_ROOT:-/home/conda/recipe_root}"
 export CI_SUPPORT="${FEEDSTOCK_ROOT}/.ci_support"
 export CONFIG_FILE="${CI_SUPPORT}/${CONFIG}.yaml"
@@ -18,8 +24,9 @@ conda-build:
  root-dir: ${FEEDSTOCK_ROOT}/build_artifacts
 
 CONDARC
+BUILD_CMD=build
 
-conda install --yes --quiet "conda-forge-ci-setup=3" conda-build pip -c conda-forge
+conda install --yes --quiet "conda-forge-ci-setup=3" conda-build pip ${GET_BOA:-} -c conda-forge
 
 # set up the condarc
 setup_conda_rc "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
@@ -29,28 +36,37 @@ source run_conda_forge_build_setup
 # make the build number clobber
 make_build_number "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
 
-if [[ "${HOST_PLATFORM}" != "${BUILD_PLATFORM}" ]]; then
+if [[ "${HOST_PLATFORM}" != "${BUILD_PLATFORM}" ]] && [[ "${BUILD_WITH_CONDA_DEBUG:-0}" != 1 ]]; then
      EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --no-test"
 fi
 
+endgroup "Configuring conda"
 
 if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
+    startgroup "Running conda debug"
     if [[ "x${BUILD_OUTPUT_ID:-}" != "x" ]]; then
         EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --output-id ${BUILD_OUTPUT_ID}"
     fi
     conda debug "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
         ${EXTRA_CB_OPTIONS:-} \
         --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml"
+    endgroup "Running conda debug"
     # Drop into an interactive shell
     /bin/bash
 else
-    conda build "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
+    startgroup "Running conda $BUILD_CMD"
+    conda $BUILD_CMD "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
         --suppress-variables ${EXTRA_CB_OPTIONS:-} \
         --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml"
+    endgroup "Running conda build"
+    startgroup "Validating outputs"
     validate_recipe_outputs "${FEEDSTOCK_NAME}"
+    endgroup "Validating outputs"
 
     if [[ "${UPLOAD_PACKAGES}" != "False" ]]; then
+        startgroup "Uploading packages"
         upload_package --validate --feedstock-name="${FEEDSTOCK_NAME}"  "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
+        endgroup "Uploading packages"
     fi
 fi
 

--- a/.scripts/logging_utils.sh
+++ b/.scripts/logging_utils.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# Provide a unified interface for the different logging
+# utilities CI providers offer. If unavailable, provide
+# a compatible fallback (e.g. bare `echo xxxxxx`).
+
+function startgroup {
+    # Start a foldable group of log lines
+    # Pass a single argument, quoted
+    case ${CI:-} in
+        azure )
+            echo "##[group]$1";;
+        travis )
+            echo "$1"
+            echo -en 'travis_fold:start:'"${1// /}"'\\r';;
+        * )
+            echo "$1";;
+    esac
+}
+
+function endgroup {
+    # End a foldable group of log lines
+    # Pass a single argument, quoted
+    case ${CI:-} in
+        azure )
+            echo "##[endgroup]";;
+        travis )
+            echo -en 'travis_fold:end:'"${1// /}"'\\r';;
+    esac
+}

--- a/.scripts/run_docker_build.sh
+++ b/.scripts/run_docker_build.sh
@@ -5,6 +5,10 @@
 # changes to this script, consider a proposal to conda-smithy so that other feedstocks can also
 # benefit from the improvement.
 
+source .scripts/logging_utils.sh
+
+startgroup "Configure Docker"
+
 set -xeo pipefail
 
 THISDIR="$( cd "$( dirname "$0" )" >/dev/null && pwd )"
@@ -65,7 +69,9 @@ DOCKER_RUN_ARGS="${CONDA_FORGE_DOCKER_RUN_ARGS}"
 if [ -z "${CI}" ]; then
     DOCKER_RUN_ARGS="-it ${DOCKER_RUN_ARGS}"
 fi
+endgroup "Configure Docker"
 
+startgroup "Start Docker"
 export UPLOAD_PACKAGES="${UPLOAD_PACKAGES:-True}"
 docker run ${DOCKER_RUN_ARGS} \
            -v "${RECIPE_ROOT}":/home/conda/recipe_root:rw,z,delegated \

--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -1,29 +1,24 @@
 #!/usr/bin/env bash
 
+source .scripts/logging_utils.sh
+
 set -x
 
-echo -e "\n\nInstalling a fresh version of Miniforge."
-if [[ ${CI} == "travis" ]]; then
-  echo -en 'travis_fold:start:install_miniforge\\r'
-fi
+startgroup "Installing a fresh version of Miniforge"
 MINIFORGE_URL="https://github.com/conda-forge/miniforge/releases/latest/download"
 MINIFORGE_FILE="Miniforge3-MacOSX-x86_64.sh"
 curl -L -O "${MINIFORGE_URL}/${MINIFORGE_FILE}"
 bash $MINIFORGE_FILE -b
-if [[ ${CI} == "travis" ]]; then
-  echo -en 'travis_fold:end:install_miniforge\\r'
-fi
+endgroup "Installing a fresh version of Miniforge"
 
-echo -e "\n\nConfiguring conda."
-if [[ ${CI} == "travis" ]]; then
-  echo -en 'travis_fold:start:configure_conda\\r'
-fi
+startgroup "Configuring conda"
+BUILD_CMD=build
 
 source ${HOME}/miniforge3/etc/profile.d/conda.sh
 conda activate base
 
 echo -e "\n\nInstalling conda-forge-ci-setup=3 and conda-build."
-conda install -n base --quiet --yes "conda-forge-ci-setup=3" conda-build pip
+conda install -n base --quiet --yes "conda-forge-ci-setup=3" conda-build pip ${GET_BOA:-}
 
 
 
@@ -39,23 +34,26 @@ echo -e "\n\nRunning the build setup script."
 source run_conda_forge_build_setup
 
 
-if [[ ${CI} == "travis" ]]; then
-  echo -en 'travis_fold:end:configure_conda\\r'
-fi
+endgroup "Configuring conda"
 
 set -e
 
-echo -e "\n\nMaking the build clobber file and running the build."
+startgroup "Running conda $BUILD_CMD"
+echo -e "\n\nMaking the build clobber file"
 make_build_number ./ ./recipe ./.ci_support/${CONFIG}.yaml
 
 if [[ "${HOST_PLATFORM}" != "${BUILD_PLATFORM}" ]]; then
     EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --no-test"
 fi
 
-conda build ./recipe -m ./.ci_support/${CONFIG}.yaml --suppress-variables --clobber-file ./.ci_support/clobber_${CONFIG}.yaml ${EXTRA_CB_OPTIONS:-}
+conda $BUILD_CMD ./recipe -m ./.ci_support/${CONFIG}.yaml --suppress-variables --clobber-file ./.ci_support/clobber_${CONFIG}.yaml ${EXTRA_CB_OPTIONS:-}
+endgroup "Running conda build"
+startgroup "Validating outputs"
 validate_recipe_outputs "${FEEDSTOCK_NAME}"
+endgroup "Validating outputs"
 
 if [[ "${UPLOAD_PACKAGES}" != "False" ]]; then
-  echo -e "\n\nUploading the packages."
+  startgroup "Uploading packages"
   upload_package --validate --feedstock-name="${FEEDSTOCK_NAME}" ./ ./recipe ./.ci_support/${CONFIG}.yaml
+  endgroup "Uploading packages"
 fi

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,5 +1,5 @@
 BSD 3-clause license
-Copyright (c) 2015-2020, conda-forge contributors
+Copyright (c) 2015-2021, conda-forge contributors
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:

--- a/README.md
+++ b/README.md
@@ -179,9 +179,9 @@ build distinct package versions.
 
 In order to produce a uniquely identifiable distribution:
  * If the version of a package **is not** being increased, please add or increase
-   the [``build/number``](https://conda.io/docs/user-guide/tasks/build-packages/define-metadata.html#build-number-and-string).
+   the [``build/number``](https://docs.conda.io/projects/conda-build/en/latest/resources/define-metadata.html#build-number-and-string).
  * If the version of a package **is** being increased, please remember to return
-   the [``build/number``](https://conda.io/docs/user-guide/tasks/build-packages/define-metadata.html#build-number-and-string)
+   the [``build/number``](https://docs.conda.io/projects/conda-build/en/latest/resources/define-metadata.html#build-number-and-string)
    back to 0.
 
 Feedstock Maintainers

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,0 +1,20 @@
+mkdir build
+cd build
+
+:: workaround for winflexbison problem, see https://github.com/conda-forge/winflexbison-feedstock/issues/6
+set BISON_PKGDATADIR=%BUILD_PREFIX%\Library\share\winflexbison\data
+
+:: cmake
+cmake -G "Ninja" ^
+    -DCMAKE_INSTALL_PREFIX:PATH="%PREFIX%" ^
+    -DCMAKE_BUILD_TYPE:STRING=Release ^
+    .. || goto :eof
+
+:: build
+cmake --build . --config Release -j %CPU_COUNT% || goto :eof
+
+:: test
+ctest -C Release || goto :eof
+
+:: install
+cmake --build . --config Release --target install || goto :eof

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,3 +1,5 @@
+@echo on
+
 mkdir build
 cd build
 
@@ -13,8 +15,14 @@ cmake -G "Ninja" ^
 :: build
 cmake --build . --config Release -j %CPU_COUNT% || goto :eof
 
-:: test
-ctest -C Release || goto :eof
+:: test - xmllint, diff and perl are required
+where xmllint || goto :eof
+where diff || goto :eof
+perl --version || goto :eof
+ctest --output-on-failure -C Release || goto :eof
 
 :: install
 cmake --build . --config Release --target install || goto :eof
+
+:: move binaries from "bin" to the more standard "Scripts" directory in env
+move "%PREFIX%\bin\doxy*.exe" "%PREFIX%\Scripts"

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -8,7 +8,7 @@ set BISON_PKGDATADIR=%BUILD_PREFIX%\Library\share\winflexbison\data
 
 :: cmake
 cmake -G "Ninja" ^
-    -DCMAKE_INSTALL_PREFIX:PATH="%PREFIX%" ^
+    -DCMAKE_INSTALL_PREFIX:PATH="%LIBRARY_PREFIX%" ^
     -DCMAKE_BUILD_TYPE:STRING=Release ^
     .. || goto :eof
 
@@ -23,6 +23,3 @@ ctest --output-on-failure -C Release || goto :eof
 
 :: install
 cmake --build . --config Release --target install || goto :eof
-
-:: move binaries from "bin" to the more standard "Scripts" directory in env
-move "%PREFIX%\bin\doxy*.exe" "%PREFIX%\Scripts"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,45 +6,36 @@ package:
   version: {{ version }}
 
 source:
-  fn: {{ name }}-{{ version }}.src.tar.gz  # [not win]
-  url: http://doxygen.nl/files/{{ name }}-{{ version }}.src.tar.gz  # [not win]
-  sha256: da8a393b7f8b7442653475a0a4bc6eaa9ce60623440d14a82fef4e8d99da4b85  # [not win]
+  fn: {{ name }}-{{ version }}.src.tar.gz
+  url: http://doxygen.nl/files/{{ name }}-{{ version }}.src.tar.gz
+  sha256: da8a393b7f8b7442653475a0a4bc6eaa9ce60623440d14a82fef4e8d99da4b85
 
-  fn: {{ name }}-{{ version }}.windows.x64.bin.zip  # [win]
-  url: http://doxygen.nl/files/{{ name }}-{{ version }}.windows.x64.bin.zip  # [win]
-  sha256: deb8e6e5f21c965ec07fd32589d0332eff047f2c8658b5c56be4839a5dd43353  # [win]
-
-  patches:   # [not win]
+  patches:
     # CMake finds iconv_open in glibc, but finds iconv.h from libiconv.
     # Make sure both are found from one place.
-    - find_iconv.patch                                                           # [not win]
+    - find_iconv.patch
 
 build:
-  number: 0
-  script:   # [win]
-    - mkdir %SCRIPTS%                                      # [win]
-    - copy doxygen.exe %SCRIPTS%\ || goto :eof             # [win]
-    - copy doxyindexer.exe %SCRIPTS%\ || goto :eof         # [win]
-    - copy doxysearch.cgi.exe %SCRIPTS%\ || goto :eof      # [win]
-    - copy libclang.dll %LIBRARY_BIN%\ || goto :eof        # [win]
-    - copy libclang.dll %LIBRARY_BIN%\ || goto :eof        # [win]
-    - copy %RECIPE_DIR%\LICENSE %SRC_DIR%\ || goto :eof    # [win]
+  number: 1
 
-requirements:   # [not win]
-  build:   # [not win]
-    - {{ compiler('c') }}  # [not win]
-    - {{ compiler('cxx') }}  # [not win]
-    - bison         # [not win]
-    - cmake         # [not win]
-    - make          # [not win]
-    - flex          # [not win]
-    - m4            # [not win]
-    - python        # [not win]
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+    - bison  # [not win]
+    - cmake
+    - flex  # [not win]
+    - m4  # [not win]
+    - make  # [not win]
+    - miktex  # [win]
+    - ninja  # [win]
+    - python
     - texlive-core  # [not win]
-  host:   # [not win]
-    - libiconv      # [not win]
-  run:   # [not win]
-    - libiconv      # [not win]
+    - winflexbison  # [win]
+  host:
+    - libiconv
+  run:
+    - libiconv
 
 test:
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,13 +25,18 @@ requirements:
     - bison  # [not win]
     - cmake
     - flex  # [not win]
+    - libxml2  # [win]  # xmllint.exe used for testing inside building step
     - m4  # [not win]
     - make  # [not win]
-    - miktex  # [win]
+    - miktex  # [win]  # used for testing inside building step
     - ninja  # [win]
     - python
     - texlive-core  # [not win]
     - winflexbison  # [win]
+    - m2-diffutils  # [win]  # diff.exe used for testing inside building step
+    - m2-libiconv  # [win]  # undeclared dependency of m2-diffutils
+    - m2-libintl  # [win]  # undeclared dependency of m2-diffutils
+    - perl  # [win]  # perl.exe is used for testing inside building step
   host:
     - libiconv
   run:


### PR DESCRIPTION
instead of repackaging the upstream binary.

The upstream binary bundles `libclang.dll`, and this clobbers the same
file from `libclang` package.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
